### PR TITLE
Enable building kustomize in memory with helm support

### DIFF
--- a/examples/reuse-kustomize/multibases/base/kustomization.yaml
+++ b/examples/reuse-kustomize/multibases/base/kustomization.yaml
@@ -1,2 +1,15 @@
 resources:
-- pod.yaml
+  - pod.yaml
+
+helmCharts:
+  - name: minecraft
+    includeCRDs: false
+    valuesInline:
+      minecraftServer:
+        eula: true
+        difficulty: hard
+        rcon:
+          enabled: true
+    releaseName: moria
+    version: 3.1.3
+    repo: https://itzg.github.io/minecraft-server-charts

--- a/lib/filesys/sandboxfs.go
+++ b/lib/filesys/sandboxfs.go
@@ -1,0 +1,124 @@
+package filesys
+
+import (
+	"errors"
+	"path/filepath"
+	"strings"
+
+	"sigs.k8s.io/kustomize/kyaml/filesys"
+)
+
+type SandboxFS struct {
+	sandboxSrc  string
+	sandboxRoot string
+	sandboxDst  string
+	fs          filesys.FileSystem
+}
+
+func NewSandboxFS(fs filesys.FileSystem, path string) (*SandboxFS, error) {
+	sandboxRoot, err := filesys.NewTmpConfirmedDir()
+	if err != nil {
+		return nil, err
+	}
+	return &SandboxFS{
+		sandboxRoot: string(sandboxRoot),
+		sandboxDst:  filepath.Join(string(sandboxRoot), path),
+		sandboxSrc:  path,
+		fs:          fs,
+	}, nil
+}
+
+// CleanedAbs implements filesys.FileSystem.
+func (s *SandboxFS) CleanedAbs(path string) (filesys.ConfirmedDir, string, error) {
+	if !filepath.IsAbs(path) {
+		return s.CleanedAbs(filepath.Join(s.sandboxDst, path))
+	}
+
+	if d, n, err := filesys.MakeFsOnDisk().CleanedAbs(path); err == nil {
+		return d, n, nil
+	}
+
+	d, n, err := s.fs.CleanedAbs(strings.TrimPrefix(path, s.sandboxRoot))
+	d = filesys.ConfirmedDir(filepath.Join(s.sandboxRoot, string(d)))
+	return d, n, err
+}
+
+// Create implements filesys.FileSystem.
+func (s *SandboxFS) Create(path string) (filesys.File, error) {
+	return filesys.MakeFsOnDisk().Create(path)
+}
+
+// Exists implements filesys.FileSystem.
+func (s *SandboxFS) Exists(path string) bool {
+	return filesys.MakeFsOnDisk().Exists(path) || s.fs.Exists(strings.TrimPrefix(path, s.sandboxRoot))
+}
+
+// Glob implements filesys.FileSystem.
+func (s *SandboxFS) Glob(pattern string) ([]string, error) {
+	rs, errs := filesys.MakeFsOnDisk().Glob(pattern)
+	rf, errf := s.fs.Glob(strings.TrimPrefix(pattern, s.sandboxRoot))
+	for i := range rf {
+		rf[i] = filepath.Join(s.sandboxRoot, rf[i])
+	}
+	return uniqueStrings(append(rs, rf...)), errors.Join(errs, errf)
+}
+
+// IsDir implements filesys.FileSystem.
+func (s *SandboxFS) IsDir(path string) bool {
+	return filesys.MakeFsOnDisk().IsDir(path) || s.fs.IsDir(strings.TrimPrefix(path, s.sandboxRoot))
+}
+
+// Mkdir implements filesys.FileSystem.
+func (s *SandboxFS) Mkdir(path string) error {
+	return filesys.MakeFsOnDisk().Mkdir(path)
+}
+
+// MkdirAll implements filesys.FileSystem.
+func (s *SandboxFS) MkdirAll(path string) error {
+	return filesys.MakeFsOnDisk().MkdirAll(path)
+}
+
+// Open implements filesys.FileSystem.
+func (s *SandboxFS) Open(path string) (filesys.File, error) {
+	if filesys.MakeFsOnDisk().Exists(path) {
+		return filesys.MakeFsOnDisk().Open(path)
+	}
+	return s.fs.Open(strings.TrimPrefix(path, s.sandboxRoot))
+}
+
+// ReadDir implements filesys.FileSystem.
+func (s *SandboxFS) ReadDir(path string) ([]string, error) {
+	if filesys.MakeFsOnDisk().Exists(path) {
+		return filesys.MakeFsOnDisk().ReadDir(path)
+	}
+	r, err := s.fs.ReadDir(strings.TrimPrefix(path, s.sandboxRoot))
+	for i := range r {
+		r[i] = filepath.Join(s.sandboxRoot, r[i])
+	}
+	return r, err
+}
+
+// ReadFile implements filesys.FileSystem.
+func (s *SandboxFS) ReadFile(path string) ([]byte, error) {
+	if filesys.MakeFsOnDisk().Exists(path) {
+		return filesys.MakeFsOnDisk().ReadFile(path)
+	}
+	return s.fs.ReadFile(strings.TrimPrefix(path, s.sandboxRoot))
+}
+
+// RemoveAll implements filesys.FileSystem.
+func (s *SandboxFS) RemoveAll(path string) error {
+	return filesys.MakeFsOnDisk().RemoveAll(path)
+}
+
+// Walk implements filesys.FileSystem.
+func (s *SandboxFS) Walk(path string, walkFn filepath.WalkFunc) error {
+	panic("not implemented")
+}
+
+// WriteFile implements filesys.FileSystem.
+func (s *SandboxFS) WriteFile(path string, data []byte) error {
+	return filesys.MakeFsOnDisk().WriteFile(path, data)
+}
+
+var _ filesys.FileSystem = &SandboxFS{}

--- a/lib/filesys/sandboxfs.go
+++ b/lib/filesys/sandboxfs.go
@@ -2,6 +2,7 @@ package filesys
 
 import (
 	"errors"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -119,6 +120,10 @@ func (s *SandboxFS) Walk(path string, walkFn filepath.WalkFunc) error {
 // WriteFile implements filesys.FileSystem.
 func (s *SandboxFS) WriteFile(path string, data []byte) error {
 	return filesys.MakeFsOnDisk().WriteFile(path, data)
+}
+
+func (s *SandboxFS) Delete() {
+	os.RemoveAll(s.sandboxRoot)
 }
 
 var _ filesys.FileSystem = &SandboxFS{}

--- a/lib/filesys/util.go
+++ b/lib/filesys/util.go
@@ -1,0 +1,14 @@
+package filesys
+
+import "sort"
+
+func uniqueStrings(input []string) []string {
+	sort.Strings(input)
+	unique := input[:0]
+	for i, s := range input {
+		if i == 0 || s != input[i-1] {
+			unique = append(unique, s)
+		}
+	}
+	return unique
+}

--- a/lib/kustomize.go
+++ b/lib/kustomize.go
@@ -55,10 +55,10 @@ func BuildKustomizeLayer(path string, buildFS func(fs filesys.FileSystem) error)
 	defer fs.Delete()
 	FailOnError(err)
 
-	return BuildKustomizeDir(fs, path)
+	return buildKustomizeDir(fs, path)
 }
 
-func BuildKustomizeDir(fs filesys.FileSystem, path string) (result ResourceList) {
+func buildKustomizeDir(fs filesys.FileSystem, path string) (result ResourceList) {
 	options := krusty.MakeDefaultOptions()
 	options.PluginConfig = types.EnabledPluginConfig(types.BploUseStaticallyLinked)
 	options.PluginConfig.HelmConfig.Enabled = true
@@ -73,6 +73,10 @@ func BuildKustomizeDir(fs filesys.FileSystem, path string) (result ResourceList)
 		result.Append(NewResource(r.RNode))
 	}
 	return
+}
+
+func BuildKustomizeDir(path string) ResourceList {
+	return buildKustomizeDir(filesys.MakeFsOnDisk(), path)
 }
 
 func EmbedFilesysBuilder(embedFS embed.FS) func(filesys.FileSystem) error {

--- a/lib/kustomize.go
+++ b/lib/kustomize.go
@@ -52,6 +52,7 @@ func BuildKustomizeLayer(path string, buildFS func(fs filesys.FileSystem) error)
 	}
 
 	fs, err := kimerize_filesys.NewSandboxFS(inMemoryFileSystem, "")
+	defer fs.Delete()
 	FailOnError(err)
 
 	return BuildKustomizeDir(fs, path)

--- a/lib/kustomize.go
+++ b/lib/kustomize.go
@@ -4,7 +4,6 @@ import (
 	"embed"
 	"fmt"
 	"io/fs"
-	"os"
 	"path/filepath"
 
 	kimerize_filesys "github.com/kimerize/kimerize/lib/filesys"
@@ -47,50 +46,25 @@ func BuildKustomizeLayer(path string, buildFS func(fs filesys.FileSystem) error)
 		FailOnError(fmt.Errorf("path must be local"))
 	}
 
-	tmpDir, err := os.MkdirTemp("", "kustomize-*")
-	if err != nil {
-		FailOnError(err)
-	}
-	defer func() {
-		go os.RemoveAll(tmpDir)
-	}()
-
 	inMemoryFileSystem := kimerize_filesys.MakeFsInMemory()
 	if err := buildFS(inMemoryFileSystem); err != nil {
 		FailOnError(err)
 	}
 
-	fs := filesys.MakeFsOnDisk()
-	err = inMemoryFileSystem.Walk("/", func(path string, info os.FileInfo, err error) error {
-		if err != nil {
-			return err
-		}
-		if info.IsDir() {
-			return fs.MkdirAll(filepath.Join(tmpDir, path))
-		} else {
-			content, err := inMemoryFileSystem.ReadFile(path)
-			if err != nil {
-				return err
-			}
-			return fs.WriteFile(filepath.Join(tmpDir, path), content)
-		}
-	})
+	fs, err := kimerize_filesys.NewSandboxFS(inMemoryFileSystem, "")
+	FailOnError(err)
 
-	if err != nil {
-		FailOnError(err)
-	}
-
-	return BuildKustomizeDir(filepath.Join(tmpDir, path))
+	return BuildKustomizeDir(fs, path)
 }
 
-func BuildKustomizeDir(path string) (result ResourceList) {
+func BuildKustomizeDir(fs filesys.FileSystem, path string) (result ResourceList) {
 	options := krusty.MakeDefaultOptions()
 	options.PluginConfig = types.EnabledPluginConfig(types.BploUseStaticallyLinked)
 	options.PluginConfig.HelmConfig.Enabled = true
 	options.PluginConfig.HelmConfig.Command = "helm"
 	options.PluginConfig.FnpLoadingOptions.EnableExec = true
 	k := krusty.MakeKustomizer(options)
-	rm, err := k.Run(filesys.MakeFsOnDisk(), filepath.Join(path, "."))
+	rm, err := k.Run(fs, filepath.Join(path, "."))
 	if err != nil {
 		FailOnError(err)
 	}


### PR DESCRIPTION
Since the helm plugin doesn't use kustomize's filesys API, we need to create a temporary dir and match paths between inmemory and disk filesystem to be able to download and render helm charts.